### PR TITLE
Cleanup

### DIFF
--- a/EZLogger.Console/DefaultConsoleMessageFormatter.cs
+++ b/EZLogger.Console/DefaultConsoleMessageFormatter.cs
@@ -7,20 +7,7 @@ namespace EZLogger.Console
 {
     public class DefaultConsoleMessageFormatter : Formatter<string>
     {
-        private static Dictionary<LogLevel, string> _logLevels;
-
-        public DefaultConsoleMessageFormatter()
-        {
-            if(_logLevels == null)
-            {
-                _logLevels = new Dictionary<LogLevel, string>();
-
-                foreach(var level in Enum.GetValues(typeof(LogLevel)))
-                {
-                    _logLevels.Add((LogLevel)level, Enum.GetName(typeof(LogLevel), level));
-                }
-            }
-        }
+        public DefaultConsoleMessageFormatter() : base() { }
 
         public override string FormatMessage(LogMessage message)
         {
@@ -30,7 +17,7 @@ namespace EZLogger.Console
             {
                 sb.Append(message.Date.ToLongDateString()).Append(" ")
                     .Append(message.Date.ToLongTimeString()).Append(" - ")
-                    .Append(_logLevels[message.Level]).Append(" - ")
+                    .Append(LogLevels[message.Level]).Append(" - ")
                     .Append(message.Message)
                     .Append(GetExceptionDetails(message.Exception));
             }

--- a/EZLogger.Console/EZLogger.Console.csproj
+++ b/EZLogger.Console/EZLogger.Console.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseUrl>https://github.com/DillonAd/EZLogger/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/DillonAd/EZLogger</RepositoryUrl>
     <PackageTags>logging easy simple</PackageTags>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EZLogger.File/DefaultFileMessageFormatter.cs
+++ b/EZLogger.File/DefaultFileMessageFormatter.cs
@@ -14,7 +14,7 @@ namespace EZLogger.File
             {
                 sb.Append(message.Date.ToLongDateString()).Append(" ")
                   .Append(message.Date.ToLongTimeString()).Append(" - ")
-                  .Append(Enum.GetName(typeof(LogLevel), message.Level)).Append(" - ");
+                  .Append(LogLevels[message.Level]).Append(" - ");
 
                 if(!string.IsNullOrWhiteSpace(message.Message))
                 {

--- a/EZLogger.File/DefaultFileMessageFormatter.cs
+++ b/EZLogger.File/DefaultFileMessageFormatter.cs
@@ -8,27 +8,27 @@ namespace EZLogger.File
     {
         public override string FormatMessage(LogMessage message)
         {
-            if (message != null && !string.IsNullOrWhiteSpace(message.Message))
-            {
-                var sb = new StringBuilder();
+            var sb = new StringBuilder();
 
+            if (message != null)
+            {
                 sb.Append(message.Date.ToLongDateString()).Append(" ")
                   .Append(message.Date.ToLongTimeString()).Append(" - ")
-                  .Append(Enum.GetName(typeof(LogLevel), message.Level)).Append(" - ")
-                  .Append(message.Message);
-                
+                  .Append(Enum.GetName(typeof(LogLevel), message.Level)).Append(" - ");
+
+                if(!string.IsNullOrWhiteSpace(message.Message))
+                {
+                    sb.Append(message.Message);
+                }
+
                 if(message.Exception != null)
                 {
                     sb.Append(Environment.NewLine)
-                      .Append(GetExceptionDetails(message.Exception));
+                        .Append(GetExceptionDetails(message.Exception));
                 }
-
-                return sb.ToString();
             }
-            else
-            {
-                return string.Empty;   
-            }
+            
+            return sb.ToString();
         }
     }
 }

--- a/EZLogger.File/EZLogger.File.csproj
+++ b/EZLogger.File/EZLogger.File.csproj
@@ -8,7 +8,7 @@
     <PackageLicenseUrl>https://github.com/DillonAd/EZLogger/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/DillonAd/EZLogger</RepositoryUrl>
     <PackageTags>logging easy simple</PackageTags>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EZLogger.Test/DefaultConsoleMessageFormatTests.cs
+++ b/EZLogger.Test/DefaultConsoleMessageFormatTests.cs
@@ -1,0 +1,123 @@
+﻿using EZLogger.Console;
+using EZLogger.Test.Utility;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace EZLogger.Test
+{
+    public class DefaultConsoleMessageFormatTests
+    {
+        [Theory]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Info)]
+        [InlineData(LogLevel.Warning)]
+        [Trait("Category", "unit")]
+        public void ConsoleMessageFormat_Level(LogLevel level)
+        {
+            // Assemble
+            string message = "test message";
+
+            LogMessage msg = new LogMessage(level, message);
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+
+            // Assert
+            Assert.Contains(Enum.GetName(typeof(LogLevel), level), result);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ConsoleMessageFormat_Message()
+        {
+            // Assemble
+            string message = "test message";
+
+            LogMessage msg = new LogMessage(LogLevel.Critical, message);
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+            
+            // Assert
+            Assert.Contains(message, result);
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Info)]
+        [InlineData(LogLevel.Warning)]
+        [Trait("Category", "unit")]
+        public void ConsoleMessageFormat_Exception_Level(LogLevel level)
+        {
+            // Assemble
+            string message = "test message";
+            Exception ex = TestExceptionGenerator.GetValidException(message);
+
+            LogMessage msg = new LogMessage(level, ex);
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+
+            // Assert
+            Assert.Contains(Enum.GetName(typeof(LogLevel), level), result);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ConsoleMessageFormat_Exception_Message()
+        {
+            // Assemble
+            string message = "test message";
+            Exception ex = TestExceptionGenerator.GetValidException(message);
+
+            LogMessage msg = new LogMessage(LogLevel.Info, ex);
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+
+            // Assert
+            Assert.Contains(ex.Message, result);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void ConsoleMessageFormat_Exception_StackTrace()
+        {
+            // Assemble
+            string message = "test message";
+            Exception ex = TestExceptionGenerator.GetValidException(message);
+
+            LogMessage msg = new LogMessage(LogLevel.Debug, ex);
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+
+            // Assert
+            Assert.Contains(ex.StackTrace, result);
+        }
+
+        [Fact]
+        public void ConsoleMessageFormat_NullLogMessage()
+        {
+            // Assemble
+            LogMessage msg = null;
+            IFormatter<string> formatter = new DefaultConsoleMessageFormatter();
+            
+            // Act
+            string result = formatter.FormatMessage(msg);
+
+            // Assert
+            Assert.Empty(result);
+        }
+    }
+}

--- a/EZLogger.Test/DefaultFileMessageFormatTests.cs
+++ b/EZLogger.Test/DefaultFileMessageFormatTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace EZLogger.Test
 {
-    public class FileMessageFormatTests
+    public class DefaultFileMessageFormatTests
     {
         [Theory]
         [InlineData(LogLevel.Debug)]

--- a/EZLogger.Test/EZLogger.Test.csproj
+++ b/EZLogger.Test/EZLogger.Test.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EZLogger.Console\EZLogger.Console.csproj" />
     <ProjectReference Include="..\EZLogger.File\EZLogger.File.csproj" />
     <ProjectReference Include="..\EZLogger\EZLogger.csproj" />
   </ItemGroup>

--- a/EZLogger.Test/FileMessageFormatTests.cs
+++ b/EZLogger.Test/FileMessageFormatTests.cs
@@ -48,7 +48,7 @@ namespace EZLogger.Test
             Assert.Contains(message, result);
         }
 
-        [Theory(Skip = "Exceptions will be included after basic messages work")]
+        [Theory]
         [InlineData(LogLevel.Debug)]
         [InlineData(LogLevel.Error)]
         [InlineData(LogLevel.Info)]
@@ -70,7 +70,7 @@ namespace EZLogger.Test
             Assert.Contains(Enum.GetName(typeof(LogLevel), level), result);
         }
 
-        [Fact(Skip = "Exceptions will be included after basic messages work")]
+        [Fact]
         [Trait("Category", "unit")]
         public void FileMessageFormat_Exception_Message()
         {
@@ -88,7 +88,7 @@ namespace EZLogger.Test
             Assert.Contains(ex.Message, result);
         }
 
-        [Fact(Skip = "Exceptions will be included after basic messages work")]
+        [Fact]
         [Trait("Category", "unit")]
         public void FileMessageFormat_Exception_StackTrace()
         {

--- a/EZLogger.Test/LoggerTest.cs
+++ b/EZLogger.Test/LoggerTest.cs
@@ -35,6 +35,31 @@ namespace EZLogger.Test
             Assert.Equal(level, writtenMessages[0].Level);
         }
 
+        [Fact]
+        [Trait("Category", "unit")]
+        public void LogMessageWithLevel()
+        {
+            // Assemble
+            List<LogMessage> writtenMessages = new List<LogMessage>();
+
+            var mockObj = new Mock<IWriter>();
+            mockObj.Setup(x => x.WriteMessage(It.IsAny<LogMessage>()))
+                .Callback((LogMessage message) => writtenMessages.Add(message));
+
+            var ex = new Exception("test message");
+            LogLevel level = LogLevel.Debug;
+
+            // Act
+            using(ILogger logger = new Logger(mockObj.Object))
+            {
+                logger.LogMessage(ex, level);
+            }
+
+            // Assert
+            Assert.Single(writtenMessages);
+            Assert.Contains(ex.Message, writtenMessages[0].Message);
+            Assert.Equal(level, writtenMessages[0].Level);
+        }
         
         [Theory]
         [InlineData(LogLevel.Debug)]
@@ -63,6 +88,33 @@ namespace EZLogger.Test
             Assert.Equal(level, writtenMessages[0].Level);
         }
 
+        [Theory]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Info)]
+        [InlineData(LogLevel.Warning)]
+        [Trait("Category", "unit")]
+        public void LogException_AllLevels(LogLevel level)
+        {
+            // Assemble
+            List<LogMessage> writtenMessages = new List<LogMessage>();
+
+            var mockObj = new Mock<IWriter>();
+            mockObj.Setup(x => x.WriteMessage(It.IsAny<LogMessage>()))
+                   .Callback((LogMessage message) => writtenMessages.Add(message));
+
+            var ex = new Exception("test message");
+            
+            // Act
+            using(ILogger logger = new Logger(mockObj.Object))
+            {
+                logger.LogMessage(ex, level);
+            }
+
+            // Assert
+            Assert.Equal(level, writtenMessages[0].Level);
+        }
+
         [Fact]
         [Trait("Category", "unit")]
         public void Log_All_Messages()
@@ -80,6 +132,32 @@ namespace EZLogger.Test
             for(int i = 0; i < messageCount; i++)
             {
                 logger.LogMessage(i.ToString(), LogLevel.Info);
+            }
+
+            // Act
+            logger.Dispose();
+
+            // Assert
+            Assert.Equal(messageCount, messages.Count);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_All_Exceptions()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+
+            var logger = new Logger(writer.Object);
+
+            const int messageCount = 50;
+
+            for(int i = 0; i < messageCount; i++)
+            {
+                logger.LogMessage(new Exception(i.ToString()), LogLevel.Info);
             }
 
             // Act
@@ -117,6 +195,32 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_All_Exceptions_Text()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+
+            var logger = new Logger(writer.Object);
+
+            const int messageCount = 50;
+
+            for(int i = 0; i < messageCount; i++)
+            {
+                logger.LogMessage(new Exception(i.ToString()), LogLevel.Info);
+            }
+
+            // Act
+            logger.Dispose();
+
+            // Assert
+            Assert.All(messages, m => Assert.False(string.IsNullOrWhiteSpace(m.Message)));
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Messages_With_Timeout()
         {
             // Assemble
@@ -132,6 +236,33 @@ namespace EZLogger.Test
             for(int i = 0; i < messageCount; i++)
             {
                 logger.LogMessage(i.ToString(), LogLevel.Info);
+            }
+
+            // Act
+            logger.Dispose();
+
+            // Assert
+            Assert.NotEmpty(messages);
+            Assert.InRange(messages.Count, 0, messageCount);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Exceptions_With_Timeout()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+
+            var logger = new Logger(writer.Object);
+
+            const int messageCount = 100000;
+
+            for(int i = 0; i < messageCount; i++)
+            {
+                logger.LogMessage(new Exception(i.ToString()), LogLevel.Info);
             }
 
             // Act

--- a/EZLogger.Test/LoggerTest.cs
+++ b/EZLogger.Test/LoggerTest.cs
@@ -2,6 +2,7 @@
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace EZLogger.Test
@@ -139,6 +140,264 @@ namespace EZLogger.Test
             // Assert
             Assert.NotEmpty(messages);
             Assert.InRange(messages.Count, 0, messageCount);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Critical()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Critical("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(LogLevel.Critical, messages.First().Level);
+        }
+        
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Critical_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Critical)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Critical(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Debug()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Debug("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(LogLevel.Debug, messages.First().Level);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Debug_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Debug)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Debug(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
+        }
+        
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Error()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Error("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(LogLevel.Error, messages.First().Level);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Error_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Error)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Error(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Info()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Info("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(LogLevel.Info, messages.First().Level);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Info_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Info)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Info(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Trace()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Trace("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(messages.First().Level, LogLevel.Trace);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Trace_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Trace)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Trace(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Warning()
+        {
+            // Assemble
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.IsAny<LogMessage>()))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Warning("test");
+            }
+            
+
+            // Assert
+            Assert.Equal(LogLevel.Warning, messages.First().Level);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Warning_Message()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Warning)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Warning(messageInput);
+            }
+            
+            // Assert
+            Assert.Equal(messageInput, messages.First().Message);
         }
     }
 }

--- a/EZLogger.Test/LoggerTest.cs
+++ b/EZLogger.Test/LoggerTest.cs
@@ -57,7 +57,7 @@ namespace EZLogger.Test
 
             // Assert
             Assert.Single(writtenMessages);
-            Assert.Contains(ex.Message, writtenMessages[0].Message);
+            Assert.Contains(ex.Message, writtenMessages[0].Exception.Message);
             Assert.Equal(level, writtenMessages[0].Level);
         }
         
@@ -216,7 +216,7 @@ namespace EZLogger.Test
             logger.Dispose();
 
             // Assert
-            Assert.All(messages, m => Assert.False(string.IsNullOrWhiteSpace(m.Message)));
+            Assert.All(messages, m => Assert.False(string.IsNullOrWhiteSpace(m.Exception.Message)));
         }
 
         [Fact]
@@ -318,56 +318,6 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
-        public void Log_Critical_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Critical)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Critical(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Critical_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Critical)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Critical(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
         public void Log_Debug()
         {
             // Assemble
@@ -406,56 +356,6 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Equal(messageInput, messages.First().Message);
-        }
-        
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Debug_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Debug)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Debug(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-        
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Debug_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Debug)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Debug(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
 
         [Fact]
@@ -502,56 +402,6 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
-        public void Log_Error_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Error)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Error(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Error_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Error)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Error(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
         public void Log_Info()
         {
             // Assemble
@@ -594,57 +444,6 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
-        public void Log_Info_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Info)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Info(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Info_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Info)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Info(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
         public void Log_Trace()
         {
             // Assemble
@@ -660,7 +459,7 @@ namespace EZLogger.Test
             }
             
             // Assert
-            Assert.Equal(messages.First().Level, LogLevel.Trace);
+            Assert.Equal(LogLevel.Trace, messages.First().Level);
         }
 
         [Fact]
@@ -683,57 +482,6 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Equal(messageInput, messages.First().Message);
-        }
-
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Trace_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Trace)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Trace(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Trace_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Trace)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Trace(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
 
         [Fact]
@@ -776,56 +524,6 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Equal(messageInput, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Warning_Exception()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Warning)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Warning(ex);
-            }
-            
-            // Assert
-            Assert.Contains(messageInput, messages.First().Message);
-        }
-
-        [Fact]
-        [Trait("Category", "unit")]
-        public void Log_Warning_Exception_Stack()
-        {
-            // Assemble
-            const string messageInput = "His name was Robert Paulson.";
-
-            var messages = new List<LogMessage>();
-            var writer = new Mock<IWriter>();
-            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Warning)))
-                  .Callback<LogMessage>(m => messages.Add(m));
-            
-            var ex = new Exception(messageInput);
-
-            try { throw ex; } catch(Exception e) {  }
-
-            // Act
-            using(var logger = new Logger(writer.Object))
-            {
-                logger.Warning(ex);
-            }
-            
-            // Assert
-            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
     }
 }

--- a/EZLogger.Test/LoggerTest.cs
+++ b/EZLogger.Test/LoggerTest.cs
@@ -342,6 +342,32 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Critical_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Critical)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Critical(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Debug()
         {
             // Assemble
@@ -404,6 +430,32 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Contains(messageInput, messages.First().Message);
+        }
+        
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Debug_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Debug)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Debug(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
 
         [Fact]
@@ -474,6 +526,32 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Error_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Error)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Error(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Info()
         {
             // Assemble
@@ -536,6 +614,33 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Contains(messageInput, messages.First().Message);
+        }
+
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Info_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Info)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Info(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
 
         [Fact]
@@ -607,6 +712,32 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Trace_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Trace)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Trace(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Warning()
         {
             // Assemble
@@ -647,7 +778,6 @@ namespace EZLogger.Test
             Assert.Equal(messageInput, messages.First().Message);
         }
 
-
         [Fact]
         [Trait("Category", "unit")]
         public void Log_Warning_Exception()
@@ -670,6 +800,32 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Contains(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Warning_Exception_Stack()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Warning)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            try { throw ex; } catch(Exception e) {  }
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Warning(ex);
+            }
+            
+            // Assert
+            Assert.Contains(ex.StackTrace, messages.First().Message);
         }
     }
 }

--- a/EZLogger.Test/LoggerTest.cs
+++ b/EZLogger.Test/LoggerTest.cs
@@ -187,6 +187,30 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Critical_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Critical)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Critical(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Debug()
         {
             // Assemble
@@ -201,7 +225,6 @@ namespace EZLogger.Test
                 logger.Debug("test");
             }
             
-
             // Assert
             Assert.Equal(LogLevel.Debug, messages.First().Level);
         }
@@ -230,6 +253,30 @@ namespace EZLogger.Test
         
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Debug_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Debug)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Debug(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Error()
         {
             // Assemble
@@ -244,7 +291,6 @@ namespace EZLogger.Test
                 logger.Error("test");
             }
             
-
             // Assert
             Assert.Equal(LogLevel.Error, messages.First().Level);
         }
@@ -273,6 +319,30 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Error_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Error)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Error(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Info()
         {
             // Assemble
@@ -287,7 +357,6 @@ namespace EZLogger.Test
                 logger.Info("test");
             }
             
-
             // Assert
             Assert.Equal(LogLevel.Info, messages.First().Level);
         }
@@ -316,6 +385,30 @@ namespace EZLogger.Test
 
         [Fact]
         [Trait("Category", "unit")]
+        public void Log_Info_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Info)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Info(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
+        }
+
+        [Fact]
+        [Trait("Category", "unit")]
         public void Log_Trace()
         {
             // Assemble
@@ -330,7 +423,6 @@ namespace EZLogger.Test
                 logger.Trace("test");
             }
             
-
             // Assert
             Assert.Equal(messages.First().Level, LogLevel.Trace);
         }
@@ -357,6 +449,31 @@ namespace EZLogger.Test
             Assert.Equal(messageInput, messages.First().Message);
         }
 
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Trace_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Trace)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Trace(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
+        }
+
         [Fact]
         [Trait("Category", "unit")]
         public void Log_Warning()
@@ -373,7 +490,6 @@ namespace EZLogger.Test
                 logger.Warning("test");
             }
             
-
             // Assert
             Assert.Equal(LogLevel.Warning, messages.First().Level);
         }
@@ -398,6 +514,31 @@ namespace EZLogger.Test
             
             // Assert
             Assert.Equal(messageInput, messages.First().Message);
+        }
+
+
+        [Fact]
+        [Trait("Category", "unit")]
+        public void Log_Warning_Exception()
+        {
+            // Assemble
+            const string messageInput = "His name was Robert Paulson.";
+
+            var messages = new List<LogMessage>();
+            var writer = new Mock<IWriter>();
+            writer.Setup(w => w.WriteMessage(It.Is<LogMessage>(l => l.Level == LogLevel.Warning)))
+                  .Callback<LogMessage>(m => messages.Add(m));
+            
+            var ex = new Exception(messageInput);
+
+            // Act
+            using(var logger = new Logger(writer.Object))
+            {
+                logger.Warning(ex);
+            }
+            
+            // Assert
+            Assert.Contains(messageInput, messages.First().Message);
         }
     }
 }

--- a/EZLogger/Formatter.cs
+++ b/EZLogger/Formatter.cs
@@ -6,6 +6,21 @@ namespace EZLogger
 {
     public abstract class Formatter<T> : IFormatter<T>
     {
+        protected readonly Dictionary<LogLevel, string> LogLevels;
+
+        public Formatter()
+        {
+            if(LogLevels == null)
+            {
+                LogLevels = new Dictionary<LogLevel, string>();
+
+                foreach(var level in Enum.GetValues(typeof(LogLevel)))
+                {
+                    LogLevels.Add((LogLevel)level, Enum.GetName(typeof(LogLevel), level));
+                }
+            }
+        }
+
         public abstract T FormatMessage(LogMessage message);
 
         // This method uses string.Format instead of $ interpolation

--- a/EZLogger/Formatter.cs
+++ b/EZLogger/Formatter.cs
@@ -8,6 +8,10 @@ namespace EZLogger
     {
         public abstract T FormatMessage(LogMessage message);
 
+        // This method uses string.Format instead of $ interpolation
+        // to be backwards compatible with previous versions of C#.
+        // Once the dollar sign interpolation method is ubiquitous
+        // this can be changed to be more concise.
         protected string GetExceptionDetails(Exception ex) =>
             ex == null ? string.Empty : $"{ex.Message}\n{ex.StackTrace}\n\n{GetExceptionDetails(ex.InnerException)}";
     }

--- a/EZLogger/ILogger.cs
+++ b/EZLogger/ILogger.cs
@@ -6,10 +6,16 @@ namespace EZLogger
     {
         void LogMessage(string message, LogLevel level);
         void Critical(string message);
+        void Critical(Exception ex);
         void Debug(string message);
+        void Debug(Exception ex);
         void Error(string message);
+        void Error(Exception ex);
         void Info(string message);
+        void Info(Exception ex);
         void Trace(string message);
+        void Trace(Exception ex);
         void Warning(string message);
+        void Warning(Exception ex);
     }
 }

--- a/EZLogger/ILogger.cs
+++ b/EZLogger/ILogger.cs
@@ -5,6 +5,7 @@ namespace EZLogger
     public interface ILogger : IDisposable
     {
         void LogMessage(string message, LogLevel level);
+        void LogMessage(Exception ex, LogLevel level);
         void Critical(string message);
         void Critical(Exception ex);
         void Debug(string message);

--- a/EZLogger/ILogger.cs
+++ b/EZLogger/ILogger.cs
@@ -5,5 +5,11 @@ namespace EZLogger
     public interface ILogger : IDisposable
     {
         void LogMessage(string message, LogLevel level);
+        void Critical(string message);
+        void Debug(string message);
+        void Error(string message);
+        void Info(string message);
+        void Trace(string message);
+        void Warning(string message);
     }
 }

--- a/EZLogger/Logger.cs
+++ b/EZLogger/Logger.cs
@@ -26,20 +26,38 @@ namespace EZLogger
         public void Critical(string message) =>
             LogMessage(message, LogLevel.Critical);
 
+        public void Critical(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Critical);
+
         public void Debug(string message) =>
             LogMessage(message, LogLevel.Debug);
+
+        public void Debug(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Debug);
 
         public void Error(string message) =>
             LogMessage(message, LogLevel.Error);
 
+        public void Error(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Error);
+
         public void Info(string message) =>
             LogMessage(message, LogLevel.Info);
+
+        public void Info(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Info);
 
         public void Trace(string message) =>
             LogMessage(message, LogLevel.Trace);
 
+        public void Trace(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Trace);
+
         public void Warning(string message) =>
             LogMessage(message, LogLevel.Warning);
+
+        public void Warning(Exception ex) =>
+            LogMessage(GetExceptionMessage(ex), LogLevel.Warning);
 
         public void Dispose()
         {
@@ -57,6 +75,13 @@ namespace EZLogger
                 _writer.Dispose();
             }
         }
+
+        // This method uses string.Format instead of $ interpolation
+        // to be backwards compatible with previous versions of C#.
+        // Once the dollar sign interpolation method is ubiquitous
+        // this can be changed to be more concise.
+        private string GetExceptionMessage(Exception ex) =>
+            ex == null ? string.Empty : string.Format("{0}{1}{2}{3}", ex.Message, ex.StackTrace, Environment.NewLine, GetExceptionMessage(ex.InnerException));
 
         private void PersistMessages()
         {

--- a/EZLogger/Logger.cs
+++ b/EZLogger/Logger.cs
@@ -23,41 +23,44 @@ namespace EZLogger
         public void LogMessage(string message, LogLevel level) =>
             _messages.Enqueue(new LogMessage(level, message));
 
+        public void LogMessage(Exception ex, LogLevel level) =>
+            LogMessage(GetExceptionMessage(ex), level);
+
         public void Critical(string message) =>
             LogMessage(message, LogLevel.Critical);
 
         public void Critical(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Critical);
+            LogMessage(ex, LogLevel.Critical);
 
         public void Debug(string message) =>
             LogMessage(message, LogLevel.Debug);
 
         public void Debug(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Debug);
+            LogMessage(ex, LogLevel.Debug);
 
         public void Error(string message) =>
             LogMessage(message, LogLevel.Error);
 
         public void Error(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Error);
+            LogMessage(ex, LogLevel.Error);
 
         public void Info(string message) =>
             LogMessage(message, LogLevel.Info);
 
         public void Info(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Info);
+            LogMessage(ex, LogLevel.Info);
 
         public void Trace(string message) =>
             LogMessage(message, LogLevel.Trace);
 
         public void Trace(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Trace);
+            LogMessage(ex, LogLevel.Trace);
 
         public void Warning(string message) =>
             LogMessage(message, LogLevel.Warning);
 
         public void Warning(Exception ex) =>
-            LogMessage(GetExceptionMessage(ex), LogLevel.Warning);
+            LogMessage(ex, LogLevel.Warning);
 
         public void Dispose()
         {

--- a/EZLogger/Logger.cs
+++ b/EZLogger/Logger.cs
@@ -23,6 +23,24 @@ namespace EZLogger
         public void LogMessage(string message, LogLevel level) =>
             _messages.Enqueue(new LogMessage(level, message));
 
+        public void Critical(string message) =>
+            LogMessage(message, LogLevel.Critical);
+
+        public void Debug(string message) =>
+            LogMessage(message, LogLevel.Debug);
+
+        public void Error(string message) =>
+            LogMessage(message, LogLevel.Error);
+
+        public void Info(string message) =>
+            LogMessage(message, LogLevel.Info);
+
+        public void Trace(string message) =>
+            LogMessage(message, LogLevel.Trace);
+
+        public void Warning(string message) =>
+            LogMessage(message, LogLevel.Warning);
+
         public void Dispose()
         {
             Dispose(true);

--- a/EZLogger/Logger.cs
+++ b/EZLogger/Logger.cs
@@ -24,7 +24,7 @@ namespace EZLogger
             _messages.Enqueue(new LogMessage(level, message));
 
         public void LogMessage(Exception ex, LogLevel level) =>
-            LogMessage(GetExceptionMessage(ex), level);
+            _messages.Enqueue(new LogMessage(level, ex));
 
         public void Critical(string message) =>
             LogMessage(message, LogLevel.Critical);
@@ -78,13 +78,6 @@ namespace EZLogger
                 _writer.Dispose();
             }
         }
-
-        // This method uses string.Format instead of $ interpolation
-        // to be backwards compatible with previous versions of C#.
-        // Once the dollar sign interpolation method is ubiquitous
-        // this can be changed to be more concise.
-        private string GetExceptionMessage(Exception ex) =>
-            ex == null ? string.Empty : string.Format("{0}{1}{2}{3}", ex.Message, ex.StackTrace, Environment.NewLine, GetExceptionMessage(ex.InnerException));
 
         private void PersistMessages()
         {


### PR DESCRIPTION
 - Allowing exceptions to be formatted specifically by each media
 - Adding `DefaultConsoleMessageFormatter` tests
 - Optimizing `LogLevel` enum parsing in formatters 